### PR TITLE
included TList.h in analysis.h --> no more forward decl. of TList

### DIFF
--- a/src/analysis.h
+++ b/src/analysis.h
@@ -1,6 +1,7 @@
 #ifndef ANALYSIS
 #define ANALYSIS
 
+#include <TList.h>
 #include <TString.h>
 #include <TPolyMarker.h>
 


### PR DESCRIPTION
To resolve the issue of forward declaraction of the class "TList" in the function "void peakfinder(......)" (./src/analysis.C ; around line 463), I added the inclusion of the headerfile "TList.h" into the headerfile of analysis.C , which is "analysis.h".